### PR TITLE
handle falsy values correctly in merge logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to
 
 ### TBA
 
+## [v0.2.4] - 2022-10-17
+
+### Fixed
+
+- Handle falsy values correctly in merge logic
+
 ## [v0.2.3] - 2022-10-13
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wayfair/gqmock",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "GQMock - GraphQL Mocking Service",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/utilities/__tests__/deepMerge.test.ts
+++ b/src/utilities/__tests__/deepMerge.test.ts
@@ -141,6 +141,36 @@ describe('deepMerge', () => {
     );
   });
 
+  it('should merge data with falsy values in source', function () {
+    const source = {
+      data: {
+        item: {
+          hasThing: false,
+        },
+      },
+    };
+
+    const seed = {
+      data: {
+        item: {
+          hasThing: true,
+        },
+      },
+    };
+
+    const expectedResult = {
+      data: {
+        item: {
+          hasThing: true,
+        },
+      },
+    };
+
+    const mergeResult = deepMerge(source, seed);
+    expect(mergeResult.data).toEqual(expectedResult);
+    expect(mergeResult.warnings.length).toEqual(0);
+  });
+
   it('should merge arrays using longhand notation', function () {
     const source = {
       data: {

--- a/src/utilities/deepMerge.ts
+++ b/src/utilities/deepMerge.ts
@@ -136,7 +136,12 @@ function merge(
       } else {
         source[targetKey] = targetValue;
       }
-    } else if (source[targetKey] === null) {
+    } else if (
+      source[targetKey] === null ||
+      source[targetKey] === false ||
+      source[targetKey] === 0 ||
+      source[targetKey] === ''
+    ) {
       source[targetKey] = targetValue;
     } else {
       if (targetKey.indexOf(metaPropertyPrefix) === 0) {


### PR DESCRIPTION
## Description

The source + target merge process does not handle falsy values (`false`, `0`, etc.) properly and does not merge/adds warnings when a source value is falsy. See added test which fails on `main`.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](https://github.com/wayfair-incubator/gqmock/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
