### PR TITLE
Add support for operation names in `/graphql` path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to
 
 ### Breaking
 
-- breaking: remove `/graphql/register-schema`. Use new `/schema/register` endpoint instead.
+- breaking: remove `/graphql/register-schema`. Use new `/schema/register`
+  endpoint instead.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ and this project adheres to
 
 ### TBA
 
+## [v1.0.0] - 2023-06-22
+
+### Breaking
+
+- breaking: remove `/graphql/register-schema`. Use new `/schema/register` endpoint instead.
+
+### Added
+
+- feat: add new `/schema/register` endpoint
+- feat: add support for operation names in `/graphql` path
+
 ## [v0.6.0] - 2023-02-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -201,12 +201,13 @@ to use the registered seeds, the `mocking-sequence-id` header needs to match the
 
 | Parameter Name                | Required | Description                                                         | Type   | Default |
 | ----------------------------- | -------- | ------------------------------------------------------------------- | ------ | ------- |
-| `body.operationName`_*_         | Yes      | Name of the GraphQL operation                                       | string |         |
+| `body.operationName`_\*_      | Yes      | Name of the GraphQL operation                                       | string |         |
 | `body.query`                  | Yes      | GraphQL query                                                       | string |         |
 | `body.variables`              | No       | GraphQL query variables                                             | object | {}      |
 | `headers.mocking-sequence-id` | Yes      | Unique id of the use case context used to connect or separate seeds | string |         |
 
-_*: `body.operationName` is not required if the `operationName` is provided in the path._
+_\*: `body.operationName` is not required if the `operationName` is provided in
+the path._
 
 #### POST `http:localhost:<port>/schema/register`
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
   - [Mock server endpoints](#mock-server-endpoints)
     - [POST `http:localhost:<port>/graphql`](#post-httplocalhostportgraphql)
     - [POST `http:localhost:<port>/graphql/register-schema`](#post-httplocalhostportgraphqlregister-schema)
+    - [POST `http:localhost:<port>/schema/register`](#post-httplocalhostportschemaregister)
     - [POST `http:localhost:<port>/seed/operation`](#post-httplocalhostportseedoperation)
     - [POST `http:localhost:<port>/seed/network-error`](#post-httplocalhostportseednetwork-error)
 - [Usage](#usage)
@@ -205,6 +206,18 @@ to use the registered seeds, the `mocking-sequence-id` header needs to match the
 | `body.query`                  | Yes      | GraphQL query                                                       | string |         |
 | `body.variables`              | No       | GraphQL query variables                                             | object | {}      |
 | `headers.mocking-sequence-id` | Yes      | Unique id of the use case context used to connect or separate seeds | string |         |
+
+#### POST `http:localhost:<port>/schema/register`
+
+Schema needs to be registered first before mocked data can be retrieved.
+
+| Parameter Name                | Required | Description                                                         | Type    | Default |
+| ----------------------------- | -------- | ------------------------------------------------------------------- | ------- | ------- |
+| `body.schema`                 | Yes      | GraphQL SDL schema                                                  | string  |         |
+| `body.options`                | No       | See specific options                                                | object  | {}      |
+| `body.options.fakerConfig`    | No       | Faker.js config for GraphQL type fields                             | object  | {}      |
+| `body.options.subgraph`       | No       | Is the schema a subgraph schema                                     | boolean | false   |
+| `headers.mocking-sequence-id` | Yes      | Unique id of the use case context used to connect or separate seeds | string  |
 
 #### POST `http:localhost:<port>/graphql/register-schema`
 
@@ -397,13 +410,13 @@ const schema = `
         tags: [Tag]
         pictures: [Picture]
     }
-    
+
     type Dimensions {
         length: Int
         width: Int
         height: Int
     }
-    
+
     type Product {
         name: String
         variants: [ProductVariant]

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@
     - [`async GraphqlMockingContext.networkError`](#async-graphqlmockingcontextnetworkerror)
   - [Mock server endpoints](#mock-server-endpoints)
     - [POST `http:localhost:<port>/graphql`](#post-httplocalhostportgraphql)
-    - [POST `http:localhost:<port>/graphql/register-schema`](#post-httplocalhostportgraphqlregister-schema)
     - [POST `http:localhost:<port>/schema/register`](#post-httplocalhostportschemaregister)
     - [POST `http:localhost:<port>/seed/operation`](#post-httplocalhostportseedoperation)
     - [POST `http:localhost:<port>/seed/network-error`](#post-httplocalhostportseednetwork-error)
@@ -208,18 +207,6 @@ to use the registered seeds, the `mocking-sequence-id` header needs to match the
 | `headers.mocking-sequence-id` | Yes      | Unique id of the use case context used to connect or separate seeds | string |         |
 
 #### POST `http:localhost:<port>/schema/register`
-
-Schema needs to be registered first before mocked data can be retrieved.
-
-| Parameter Name                | Required | Description                                                         | Type    | Default |
-| ----------------------------- | -------- | ------------------------------------------------------------------- | ------- | ------- |
-| `body.schema`                 | Yes      | GraphQL SDL schema                                                  | string  |         |
-| `body.options`                | No       | See specific options                                                | object  | {}      |
-| `body.options.fakerConfig`    | No       | Faker.js config for GraphQL type fields                             | object  | {}      |
-| `body.options.subgraph`       | No       | Is the schema a subgraph schema                                     | boolean | false   |
-| `headers.mocking-sequence-id` | Yes      | Unique id of the use case context used to connect or separate seeds | string  |
-
-#### POST `http:localhost:<port>/graphql/register-schema`
 
 Schema needs to be registered first before mocked data can be retrieved.
 

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Registers a seed for a network error.
 
 ### Mock server endpoints
 
-#### POST `http:localhost:<port>/graphql`
+#### POST `http:localhost:<port>/graphql/:operationName?`
 
 Send GraphQL queries to this endpoint to retrieve mocked data. Seeds are
 overlaid onto the response if they were previously registered. The
@@ -201,10 +201,12 @@ to use the registered seeds, the `mocking-sequence-id` header needs to match the
 
 | Parameter Name                | Required | Description                                                         | Type   | Default |
 | ----------------------------- | -------- | ------------------------------------------------------------------- | ------ | ------- |
-| `body.operationName`          | Yes      | Name of the GraphQL operation                                       | string |         |
+| `body.operationName`_*_         | Yes      | Name of the GraphQL operation                                       | string |         |
 | `body.query`                  | Yes      | GraphQL query                                                       | string |         |
 | `body.variables`              | No       | GraphQL query variables                                             | object | {}      |
 | `headers.mocking-sequence-id` | Yes      | Unique id of the use case context used to connect or separate seeds | string |         |
+
+_*: `body.operationName` is not required if the `operationName` is provided in the path._
 
 #### POST `http:localhost:<port>/schema/register`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wayfair/gqmock",
-  "version": "0.6.0",
+  "version": "1.0.0",
   "description": "GQMock - GraphQL Mocking Service",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/MockServer.ts
+++ b/src/MockServer.ts
@@ -35,7 +35,7 @@ class MockServer {
     schema: string,
     options: SchemaRegistrationOptions
   ): Promise<Response> {
-    return fetch(`http://localhost:${this.port}/graphql/register-schema`, {
+    return fetch(`http://localhost:${this.port}/schema/register`, {
       method: 'post',
       body: JSON.stringify({
         schema,

--- a/src/routes/graphql.ts
+++ b/src/routes/graphql.ts
@@ -91,19 +91,6 @@ const graphqlRoutes = (
     }
   });
 
-  router.post('/register-schema', (req, res) => {
-    const {schema, options = {}} = req.body;
-    try {
-      apolloServerManager.createApolloServer(schema, options);
-    } catch (error) {
-      throw new Error(
-        `Unable to register GraphQL schema: ${(error as Error).message}.`
-      );
-    }
-
-    res.sendStatus(204);
-  });
-
   return router;
 };
 

--- a/src/routes/graphql.ts
+++ b/src/routes/graphql.ts
@@ -13,8 +13,11 @@ const graphqlRoutes = (
   }
 ): express.Router => {
   const router = createRouter();
-  router.post('/', async (req, res) => {
-    const {query = '', variables = {}, operationName} = req.body;
+  // Allow additional information in the /graphql route to allow for common patterns
+  // like putting operation names in the path for usage in APM modules
+  router.post('/:operationName?', async (req, res) => {
+    const {query = '', variables = {}} = req.body;
+    const operationName = req.body.operationName || req.params.operationName;
     const sequenceId = req.headers['mocking-sequence-id'] as string;
     if (!operationName) {
       res.status(400);

--- a/src/routes/schema.ts
+++ b/src/routes/schema.ts
@@ -1,0 +1,33 @@
+import express from 'express';
+import {parse} from 'graphql';
+import GraphqlMockingContextLogger from '../utilities/Logger';
+import createRouter from '../utilities/createRouter';
+import SeedManager from '../seed/SeedManager';
+import ApolloServerManager from '../ApolloServerManager';
+import {SeededOperationResponse} from '../seed/types';
+
+const schemaRoutes = (
+  {apolloServerManager} = {
+    apolloServerManager: new ApolloServerManager(),
+  }
+): express.Router => {
+  const router = createRouter();
+
+  router.post('/register', (req, res) => {
+    const {schema, options = {}} = req.body;
+
+    try {
+      apolloServerManager.createApolloServer(schema, options);
+    } catch (error) {
+      throw new Error(
+        `Unable to register GraphQL schema: ${(error as Error).message}.`
+      );
+    }
+
+    res.sendStatus(204);
+  });
+
+  return router;
+};
+
+export default schemaRoutes;

--- a/src/routes/schema.ts
+++ b/src/routes/schema.ts
@@ -1,10 +1,6 @@
 import express from 'express';
-import {parse} from 'graphql';
-import GraphqlMockingContextLogger from '../utilities/Logger';
 import createRouter from '../utilities/createRouter';
-import SeedManager from '../seed/SeedManager';
 import ApolloServerManager from '../ApolloServerManager';
-import {SeededOperationResponse} from '../seed/types';
 
 const schemaRoutes = (
   {apolloServerManager} = {

--- a/src/utilities/createApp.ts
+++ b/src/utilities/createApp.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import cors from 'cors';
 import graphqlRoutes from '../routes/graphql';
 import seedRoutes from '../routes/seed';
+import schemaRoutes from '../routes/schema';
 import SeedManager from '../seed/SeedManager';
 import ApolloServerManager from '../ApolloServerManager';
 
@@ -30,6 +31,7 @@ export default function createApp(): express.Express {
   });
 
   app.use('/graphql', graphqlRoutes({seedManager, apolloServerManager}));
+  app.use('/schema', schemaRoutes({apolloServerManager}));
   app.use('/seed', seedRoutes({seedManager}));
 
   return app;


### PR DESCRIPTION
## Description

* feat: add new `/schema/register` endpoint
* breaking: remove `/graphql/register-schema`
* feat: add support for operation names in `/graphql` path

I've verified this change in locally in Hunt Clubs application environment.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [x] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wayfair-incubator/gqmock/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
