### PR TITLE
feat: don't require sequenceId when executing a query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ and this project adheres to
 
 ## [Unreleased]
 
-### TBA
+### Fixed
+
+- fix: don't require sequenceId when executing a query
 
 ## [v1.0.0] - 2023-06-22
 

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ to use the registered seeds, the `mocking-sequence-id` header needs to match the
 | `body.operationName`_\*_      | Yes      | Name of the GraphQL operation                                       | string |         |
 | `body.query`                  | Yes      | GraphQL query                                                       | string |         |
 | `body.variables`              | No       | GraphQL query variables                                             | object | {}      |
-| `headers.mocking-sequence-id` | Yes      | Unique id of the use case context used to connect or separate seeds | string |         |
+| `headers.mocking-sequence-id` | No       | Unique id of the use case context used to connect or separate seeds | string |         |
 
 _\*: `body.operationName` is not required if the `operationName` is provided in
 the path._

--- a/src/seed/SeedManager.ts
+++ b/src/seed/SeedManager.ts
@@ -119,9 +119,8 @@ export default class SeedManager {
     seed: SeedCacheInstance | Record<string, never>;
     seedIndex: number;
   } {
-    this.validateSequenceId(sequenceId);
-
     if (
+      sequenceId === undefined ||
       !this.seedCache[sequenceId] ||
       !this.seedCache[sequenceId][operationName]
     ) {


### PR DESCRIPTION
## Description

Sequence Ids shouldn't be required when executing a query. In this state, we want to allow folks to use the mock server like they would any other mock server. In this state, they will just never be able to look up and leverage a seed. The mock server logs this in it's output.

<img width="868" alt="image" src="https://github.com/wayfair-incubator/gqmock/assets/7584015/26dbb428-b665-45c0-be80-1a06ee6dd25d">

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wayfair-incubator/gqmock/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
