### PR TITLE
feat: add support for serving a playground UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ and this project adheres to
 
 ### TBA
 
+## [v1.1.0] - 2023-06-28
+
+### Added
+
+- feat: add support for serving a playground UI from the mock servers `/graphql`
+  route. Three options are available:
+  - **DEFAULT** `PlaygroundUI.ApolloSandbox`: Serve's the
+    [Apollo Sandbox](https://www.apollographql.com/docs/graphos/explorer/sandbox/)
+    experience.
+  - `PlaygroundUI.GraphiQL`: Serve's the latest version of the
+    [GraphiLQ playground](https://github.com/graphql/graphiql/tree/main/packages/graphiql#readme)
+  - `PlaygroundUI.None`: Disables the playground UI
+
+### Fixed
+
+- fix: don't require sequenceId when executing a query
+
 ## [v1.0.0] - 2023-06-22
 
 ### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to
     [Apollo Sandbox](https://www.apollographql.com/docs/graphos/explorer/sandbox/)
     experience.
   - `PlaygroundUI.GraphiQL`: Serve's the latest version of the
-    [GraphiLQ playground](https://github.com/graphql/graphiql/tree/main/packages/graphiql#readme)
+    [GraphiQL playground](https://github.com/graphql/graphiql/tree/main/packages/graphiql#readme)
   - `PlaygroundUI.None`: Disables the playground UI
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,6 @@ and this project adheres to
 
 ## [Unreleased]
 
-### Fixed
-
-- fix: don't require sequenceId when executing a query
-
 ## [v1.1.0] - 2023-06-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,14 +12,14 @@ and this project adheres to
 
 ### Added
 
-- feat: add support for serving a playground UI from the mock servers `/graphql`
+- feat: add support for serving a GraphQL IDE from the mock servers `/graphql`
   route. Three options are available:
-  - **DEFAULT** `PlaygroundUI.ApolloSandbox`: Serve's the
+  - **DEFAULT** `GraphQLIDE.ApolloSandbox`: Serve's the
     [Apollo Sandbox](https://www.apollographql.com/docs/graphos/explorer/sandbox/)
     experience.
-  - `PlaygroundUI.GraphiQL`: Serve's the latest version of the
-    [GraphiQL playground](https://github.com/graphql/graphiql/tree/main/packages/graphiql#readme)
-  - `PlaygroundUI.None`: Disables the playground UI
+  - `GraphQLIDE.GraphiQL`: Serve's the latest version of
+    [GraphiQL](https://github.com/graphql/graphiql/tree/main/packages/graphiql#readme)
+  - `GraphQLIDE.None`: Disables the GraphQL IDE experience
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Three options are available:
   [Apollo Sandbox](https://www.apollographql.com/docs/graphos/explorer/sandbox/)
   experience.
 - `PlaygroundUI.GraphiQL`: Serve's the latest version of the
-  [GraphiLQ playground](https://github.com/graphql/graphiql/tree/main/packages/graphiql#readme)
+  [GraphiQL playground](https://github.com/graphql/graphiql/tree/main/packages/graphiql#readme)
 - `PlaygroundUI.None`: Disables the playground UI, and therefore this endpoint
 
 #### POST `http:localhost:<port>/graphql/:operationName?`

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
     - [`async GraphqlMockingContext.operation`](#async-graphqlmockingcontextoperation)
     - [`async GraphqlMockingContext.networkError`](#async-graphqlmockingcontextnetworkerror)
   - [Mock server endpoints](#mock-server-endpoints)
+    - [GET `http:localhost:<port>/graphql`](#get-httplocalhostportgraphql)
     - [POST `http:localhost:<port>/graphql`](#post-httplocalhostportgraphql)
     - [POST `http:localhost:<port>/schema/register`](#post-httplocalhostportschemaregister)
     - [POST `http:localhost:<port>/seed/operation`](#post-httplocalhostportseedoperation)
@@ -189,6 +190,18 @@ Registers a seed for a network error.
 | `options.statusCode`      | No       | HTTP response status code of the response                                              | number                   | 500                        |
 
 ### Mock server endpoints
+
+#### GET `http:localhost:<port>/graphql/:operationName?`
+
+This endpoint supports a playground UI from the mock servers `/graphql` route.
+Three options are available:
+
+- **DEFAULT** `PlaygroundUI.ApolloSandbox`: Serve's the
+  [Apollo Sandbox](https://www.apollographql.com/docs/graphos/explorer/sandbox/)
+  experience.
+- `PlaygroundUI.GraphiQL`: Serve's the latest version of the
+  [GraphiLQ playground](https://github.com/graphql/graphiql/tree/main/packages/graphiql#readme)
+- `PlaygroundUI.None`: Disables the playground UI, and therefore this endpoint
 
 #### POST `http:localhost:<port>/graphql/:operationName?`
 

--- a/README.md
+++ b/README.md
@@ -193,15 +193,16 @@ Registers a seed for a network error.
 
 #### GET `http:localhost:<port>/graphql/:operationName?`
 
-This endpoint supports a playground UI from the mock servers `/graphql` route.
-Three options are available:
+This endpoint supports serving a GraphQL IDE from the mock servers `/graphql`
+route. Three options are available:
 
-- **DEFAULT** `PlaygroundUI.ApolloSandbox`: Serve's the
+- **DEFAULT** `GraphQLIDE.ApolloSandbox`: Serve's the
   [Apollo Sandbox](https://www.apollographql.com/docs/graphos/explorer/sandbox/)
   experience.
-- `PlaygroundUI.GraphiQL`: Serve's the latest version of the
-  [GraphiQL playground](https://github.com/graphql/graphiql/tree/main/packages/graphiql#readme)
-- `PlaygroundUI.None`: Disables the playground UI, and therefore this endpoint
+- `GraphQLIDE.GraphiQL`: Serve's the latest version of
+  [GraphiQL](https://github.com/graphql/graphiql/tree/main/packages/graphiql#readme)
+- `GraphQLIDE.None`: Disables the GraphQL IDE experience, and therefore this
+  endpoint
 
 #### POST `http:localhost:<port>/graphql/:operationName?`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wayfair/gqmock",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "GQMock - GraphQL Mocking Service",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/GraphQLIDE.ts
+++ b/src/GraphQLIDE.ts
@@ -1,4 +1,4 @@
-export enum PlaygroundUI {
+export enum GraphQLIDE {
   None = 'None',
   GraphiQL = 'GraphiQL',
   ApolloSandbox = 'ApolloSandbox',

--- a/src/GraphqlMockingService.ts
+++ b/src/GraphqlMockingService.ts
@@ -1,11 +1,11 @@
 import GraphqlMockingContext from './GraphqlMockingContext';
-import {PlaygroundUI} from './PlaygroundUI';
+import {GraphQLIDE} from './GraphQLIDE';
 import MockServer from './MockServer';
 
 type GraphqlMockingServiceOptions = {
   port?: number;
   subgraph?: boolean;
-  playgroundUI?: PlaygroundUI;
+  graphQLIDE?: GraphQLIDE;
 };
 
 export default class GraphqlMockingService {
@@ -14,7 +14,7 @@ export default class GraphqlMockingService {
   constructor(private options: GraphqlMockingServiceOptions = {}) {
     this.server = new MockServer({
       port: options.port,
-      playgroundUI: options.playgroundUI,
+      graphQLIDE: options.graphQLIDE,
     });
     this.subgraph = options.subgraph || false;
   }

--- a/src/GraphqlMockingService.ts
+++ b/src/GraphqlMockingService.ts
@@ -1,16 +1,21 @@
 import GraphqlMockingContext from './GraphqlMockingContext';
+import {PlaygroundUI} from './PlaygroundUI';
 import MockServer from './MockServer';
 
 type GraphqlMockingServiceOptions = {
   port?: number;
   subgraph?: boolean;
+  playgroundUI?: PlaygroundUI;
 };
 
 export default class GraphqlMockingService {
   readonly server;
   private subgraph;
   constructor(private options: GraphqlMockingServiceOptions = {}) {
-    this.server = new MockServer({port: options.port});
+    this.server = new MockServer({
+      port: options.port,
+      playgroundUI: options.playgroundUI,
+    });
     this.subgraph = options.subgraph || false;
   }
 

--- a/src/MockServer.ts
+++ b/src/MockServer.ts
@@ -1,11 +1,11 @@
 import fetch, {Response} from 'node-fetch';
 import createApp from './utilities/createApp';
 import {Seed} from './seed/types';
-import {PlaygroundUI} from './PlaygroundUI';
+import {GraphQLIDE} from './GraphQLIDE';
 
 type MockServerOptions = {
   port?: number;
-  playgroundUI?: PlaygroundUI;
+  graphQLIDE?: GraphQLIDE;
 };
 
 type SchemaRegistrationOptions = {
@@ -14,15 +14,15 @@ type SchemaRegistrationOptions = {
 
 class MockServer {
   readonly port: number;
-  readonly playgroundUI: PlaygroundUI;
+  readonly graphQLIDE: GraphQLIDE;
   private appServer;
   constructor(options: MockServerOptions) {
     this.port = options.port || 5000;
-    this.playgroundUI = options.playgroundUI || PlaygroundUI.ApolloSandbox;
+    this.graphQLIDE = options.graphQLIDE || GraphQLIDE.ApolloSandbox;
   }
 
   async start(): Promise<void> {
-    const app = createApp({playgroundUI: this.playgroundUI, port: this.port});
+    const app = createApp({graphQLIDE: this.graphQLIDE, port: this.port});
 
     this.appServer = await app.listen({port: this.port}, () =>
       console.log(

--- a/src/MockServer.ts
+++ b/src/MockServer.ts
@@ -1,9 +1,11 @@
 import fetch, {Response} from 'node-fetch';
 import createApp from './utilities/createApp';
 import {Seed} from './seed/types';
+import {PlaygroundUI} from './PlaygroundUI';
 
 type MockServerOptions = {
   port?: number;
+  playgroundUI?: PlaygroundUI;
 };
 
 type SchemaRegistrationOptions = {
@@ -11,14 +13,16 @@ type SchemaRegistrationOptions = {
 };
 
 class MockServer {
-  readonly port;
+  readonly port: number;
+  readonly playgroundUI: PlaygroundUI;
   private appServer;
   constructor(options: MockServerOptions) {
     this.port = options.port || 5000;
+    this.playgroundUI = options.playgroundUI || PlaygroundUI.ApolloSandbox;
   }
 
   async start(): Promise<void> {
-    const app = createApp();
+    const app = createApp({playgroundUI: this.playgroundUI, port: this.port});
 
     this.appServer = await app.listen({port: this.port}, () =>
       console.log(

--- a/src/PlaygroundUI.ts
+++ b/src/PlaygroundUI.ts
@@ -1,0 +1,5 @@
+export enum PlaygroundUI {
+  None = 'None',
+  GraphiQL = 'GraphiQL',
+  ApolloSandbox = 'ApolloSandbox',
+}

--- a/src/__tests__/GraphqlMockingService.test.ts
+++ b/src/__tests__/GraphqlMockingService.test.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import fetch from 'node-fetch';
-import {PlaygroundUI} from '../PlaygroundUI';
+import {GraphQLIDE} from '../GraphQLIDE';
 import GraphqlMockingService from '../GraphqlMockingService';
 
 const schema = fs.readFileSync(
@@ -1115,7 +1115,7 @@ query itemsQuery { officeItems: items(type: "office") { ...commonItems3 } homeIt
       );
     });
 
-    it('returns the apollo studio sandbox by default', async () => {
+    it('returns the Apollo Sandbox GraphQL IDE by default', async () => {
       await fetch(`http://localhost:${port}/graphql`, {
         method: 'get',
       })
@@ -1130,12 +1130,12 @@ query itemsQuery { officeItems: items(type: "office") { ...commonItems3 } homeIt
         });
     });
 
-    it('returns the graphiql playground when configured', async () => {
+    it('returns the GraphiQL GraphQL IDE when configured', async () => {
       // This is pretty gross. I plan on comming back to refactor this test suite.
       await mockingService.stop();
       mockingService = new GraphqlMockingService({
         port,
-        playgroundUI: PlaygroundUI.GraphiQL,
+        graphQLIDE: GraphQLIDE.GraphiQL,
       });
       await mockingService.start();
       await fetch(`http://localhost:${port}/graphql`, {
@@ -1152,12 +1152,12 @@ query itemsQuery { officeItems: items(type: "office") { ...commonItems3 } homeIt
         });
     });
 
-    it('should return a 404 when no playground UI is configured', async () => {
+    it('should return a 404 when no GraphQL IDE UI is configured', async () => {
       // This is pretty gross. I plan on comming back to refactor this test suite.
       await mockingService.stop();
       mockingService = new GraphqlMockingService({
         port,
-        playgroundUI: PlaygroundUI.None,
+        graphQLIDE: GraphQLIDE.None,
       });
       await mockingService.start();
       await fetch(`http://localhost:${port}/graphql`, {

--- a/src/html/graphiql.ts
+++ b/src/html/graphiql.ts
@@ -1,0 +1,48 @@
+// HTML based on https://github.com/graphql/graphiql/tree/main/examples/graphiql-cdn
+export default `
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>GraphiQL</title>
+    <style>
+      body {
+        height: 100%;
+        margin: 0;
+        width: 100%;
+        overflow: hidden;
+      }
+
+      #graphiql {
+        height: 100vh;
+      }
+    </style>
+    <script
+      crossorigin
+      src="https://unpkg.com/react@18/umd/react.development.js"
+    ></script>
+    <script
+      crossorigin
+      src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"
+    ></script>
+    <link rel="stylesheet" href="https://unpkg.com/graphiql/graphiql.min.css" />
+  </head>
+  <body>
+    <div id="graphiql">Loading...</div>
+    <script
+      src="https://unpkg.com/graphiql/graphiql.min.js"
+      type="application/javascript"
+    ></script>
+    <script>
+      const root = ReactDOM.createRoot(document.getElementById('graphiql'));
+      root.render(
+        React.createElement(GraphiQL, {
+          fetcher: GraphiQL.createFetcher({
+            url: '/graphql',
+          }),
+          defaultEditorToolsVisibility: true,
+        })
+      );
+    </script>
+  </body>
+</html>
+`;

--- a/src/routes/graphql.ts
+++ b/src/routes/graphql.ts
@@ -5,14 +5,33 @@ import createRouter from '../utilities/createRouter';
 import SeedManager from '../seed/SeedManager';
 import ApolloServerManager from '../ApolloServerManager';
 import {SeededOperationResponse} from '../seed/types';
+import {PlaygroundUI} from '../PlaygroundUI';
+import graphiqlHtml from '../html/graphiql';
 
 const graphqlRoutes = (
-  {seedManager, apolloServerManager} = {
+  {playgroundUI, port, seedManager, apolloServerManager} = {
+    playgroundUI: PlaygroundUI.ApolloSandbox,
+    port: 5001,
     seedManager: new SeedManager(),
     apolloServerManager: new ApolloServerManager(),
   }
 ): express.Router => {
   const router = createRouter();
+
+  // If a playgroundUI is configured, set up a GET route to serve it
+  if (playgroundUI === PlaygroundUI.ApolloSandbox) {
+    router.get('/', (_req, res) => {
+      res.redirect(
+        301,
+        `https://studio.apollographql.com/sandbox/explorer?endpoint=http://localhost:${port}/graphql`
+      );
+    });
+  } else if (playgroundUI === PlaygroundUI.GraphiQL) {
+    router.get('/', (_req, res) => {
+      res.send(graphiqlHtml);
+    });
+  }
+
   // Allow additional information in the /graphql route to allow for common patterns
   // like putting operation names in the path for usage in APM modules
   router.post('/:operationName?', async (req, res) => {

--- a/src/routes/graphql.ts
+++ b/src/routes/graphql.ts
@@ -5,12 +5,12 @@ import createRouter from '../utilities/createRouter';
 import SeedManager from '../seed/SeedManager';
 import ApolloServerManager from '../ApolloServerManager';
 import {SeededOperationResponse} from '../seed/types';
-import {PlaygroundUI} from '../PlaygroundUI';
+import {GraphQLIDE} from '../GraphQLIDE';
 import graphiqlHtml from '../html/graphiql';
 
 const graphqlRoutes = (
-  {playgroundUI, port, seedManager, apolloServerManager} = {
-    playgroundUI: PlaygroundUI.ApolloSandbox,
+  {graphQLIDE, port, seedManager, apolloServerManager} = {
+    graphQLIDE: GraphQLIDE.ApolloSandbox,
     port: 5001,
     seedManager: new SeedManager(),
     apolloServerManager: new ApolloServerManager(),
@@ -18,15 +18,15 @@ const graphqlRoutes = (
 ): express.Router => {
   const router = createRouter();
 
-  // If a playgroundUI is configured, set up a GET route to serve it
-  if (playgroundUI === PlaygroundUI.ApolloSandbox) {
+  // If a GraphQL IDE is configured, set up a GET route to serve it
+  if (graphQLIDE === GraphQLIDE.ApolloSandbox) {
     router.get('/', (_req, res) => {
       res.redirect(
         301,
         `https://studio.apollographql.com/sandbox/explorer?endpoint=http://localhost:${port}/graphql`
       );
     });
-  } else if (playgroundUI === PlaygroundUI.GraphiQL) {
+  } else if (graphQLIDE === GraphQLIDE.GraphiQL) {
     router.get('/', (_req, res) => {
       res.send(graphiqlHtml);
     });

--- a/src/utilities/createApp.ts
+++ b/src/utilities/createApp.ts
@@ -5,11 +5,21 @@ import seedRoutes from '../routes/seed';
 import schemaRoutes from '../routes/schema';
 import SeedManager from '../seed/SeedManager';
 import ApolloServerManager from '../ApolloServerManager';
+import {PlaygroundUI} from '../PlaygroundUI';
 
 /**
+ * @param root0
+ * @param root0.playgroundUI
+ * @param root0.port
  * @returns {express.Express} An express server instance
  */
-export default function createApp(): express.Express {
+export default function createApp({
+  playgroundUI,
+  port,
+}: {
+  playgroundUI: PlaygroundUI;
+  port: number;
+}): express.Express {
   const app = express();
   const seedManager = new SeedManager();
   const apolloServerManager = new ApolloServerManager();
@@ -30,7 +40,10 @@ export default function createApp(): express.Express {
     return res;
   });
 
-  app.use('/graphql', graphqlRoutes({seedManager, apolloServerManager}));
+  app.use(
+    '/graphql',
+    graphqlRoutes({playgroundUI, seedManager, apolloServerManager, port})
+  );
   app.use('/schema', schemaRoutes({apolloServerManager}));
   app.use('/seed', seedRoutes({seedManager}));
 

--- a/src/utilities/createApp.ts
+++ b/src/utilities/createApp.ts
@@ -5,19 +5,19 @@ import seedRoutes from '../routes/seed';
 import schemaRoutes from '../routes/schema';
 import SeedManager from '../seed/SeedManager';
 import ApolloServerManager from '../ApolloServerManager';
-import {PlaygroundUI} from '../PlaygroundUI';
+import {GraphQLIDE} from '../GraphQLIDE';
 
 /**
- * @param root0
- * @param root0.playgroundUI
- * @param root0.port
+ * @param {object} root0 - The root object
+ * @param {GraphQLIDE} root0.graphQLIDE - The type of GraphQL IDE to use
+ * @param {number} root0.port - The port to run the server on
  * @returns {express.Express} An express server instance
  */
 export default function createApp({
-  playgroundUI,
+  graphQLIDE,
   port,
 }: {
-  playgroundUI: PlaygroundUI;
+  graphQLIDE: GraphQLIDE;
   port: number;
 }): express.Express {
   const app = express();
@@ -42,7 +42,7 @@ export default function createApp({
 
   app.use(
     '/graphql',
-    graphqlRoutes({playgroundUI, seedManager, apolloServerManager, port})
+    graphqlRoutes({graphQLIDE, seedManager, apolloServerManager, port})
   );
   app.use('/schema', schemaRoutes({apolloServerManager}));
   app.use('/seed', seedRoutes({seedManager}));


### PR DESCRIPTION
## Description

- feat: add support for serving a playground UI from the mock servers `/graphql`
  route. Three options are available:
  - **DEFAULT** `PlaygroundUI.ApolloSandbox`: Serve's the
    [Apollo Sandbox](https://www.apollographql.com/docs/graphos/explorer/sandbox/)
    experience.
  - `PlaygroundUI.GraphiQL`: Serve's the latest version of the
    [GraphiLQ playground](https://github.com/graphql/graphiql/tree/main/packages/graphiql#readme)
  - `PlaygroundUI.None`: Disables the playground UI
## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wayfair-incubator/gqmock/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
