### PR TITLE
fix: resolve matching arguments correctly + support nested arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [v1.1.1] - 2023-08-09
+
+### Fixed
+
+- fix: resolve matching arguments correctly + support nested arguments
+
 ## [v1.1.0] - 2023-06-28
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wayfair/gqmock",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "GQMock - GraphQL Mocking Service",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/__tests__/SeedManager.test.ts
+++ b/src/__tests__/SeedManager.test.ts
@@ -183,14 +183,17 @@ describe('Seed Manager', () => {
       const seed = {
         operationName: 'operationA',
         seedResponse: {data: {product: 'my product'}},
-        operationMatchArguments: {sku: 'abc', anotherArg: 'test'},
+        operationMatchArguments: {input: {sku: 'abc'}},
       };
       const type = SeedType.Operation;
 
       seedManager.registerSeed(sequenceId, type, seed, {partialArgs: true});
       expect(
         seedManager.findSeed(sequenceId, seed.operationName, {
-          sku: 'abc',
+          input: {
+            sku: 'abc',
+            anotherArg: 'test',
+          },
         }).seed
       ).toEqual({
         type,

--- a/src/seed/SeedManager.ts
+++ b/src/seed/SeedManager.ts
@@ -112,7 +112,7 @@ export default class SeedManager {
   }
 
   private matchArguments(
-    source: Record<string, unknown>
+    source: Record<string, unknown>,
     target: Record<string, unknown>
   ) {
     const argsMatch = Object.entries(source).every(

--- a/src/seed/SeedManager.ts
+++ b/src/seed/SeedManager.ts
@@ -112,8 +112,8 @@ export default class SeedManager {
   }
 
   private matchArguments(
-    source: Record<string, unknown>,
-    target: Record<string, unknown>
+    source: Record<string, any>, // eslint-disable-line @typescript-eslint/no-explicit-any
+    target: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
   ) {
     const argsMatch = Object.entries(source).every(
       ([argumentName, argumentValue]) => {
@@ -127,7 +127,8 @@ export default class SeedManager {
     return argsMatch;
   }
 
-  private argumentCount(args: Record<string, unknown>) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private argumentCount(args: Record<string, any>) {
     return Object.entries(args).reduce((acc, [, value]) => {
       if (typeof value === 'object') {
         return acc + this.argumentCount(value) + 1;

--- a/src/seed/SeedManager.ts
+++ b/src/seed/SeedManager.ts
@@ -112,8 +112,8 @@ export default class SeedManager {
   }
 
   private matchArguments(
-    source: Record<string, any>, // eslint-disable-line @typescript-eslint/no-explicit-any
-    target: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+    source: Record<string, unknown>
+    target: Record<string, unknown>
   ) {
     const argsMatch = Object.entries(source).every(
       ([argumentName, argumentValue]) => {
@@ -127,8 +127,7 @@ export default class SeedManager {
     return argsMatch;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private argumentCount(args: Record<string, any>) {
+  private argumentCount(args: Record<string, unknown>) {
     return Object.entries(args).reduce((acc, [, value]) => {
       if (typeof value === 'object') {
         return acc + this.argumentCount(value) + 1;


### PR DESCRIPTION
## Description

* Nested arguments weren't previously supported. Now we recursively loop through arguments and compare values
* Refactored to loop over the match arguments (instead of the execution arguments) to better support partial argument matching and the default `{}` matching argument values.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](https://github.com/wayfair-incubator/gqmock/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
