### PR TITLE
fix: handle null args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [v1.1.2] - 2023-08-21
+
+### Fixed
+
+- fix: handle null arguments
+
 ## [v1.1.1] - 2023-08-09
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wayfair/gqmock",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "GQMock - GraphQL Mocking Service",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/seed/SeedManager.ts
+++ b/src/seed/SeedManager.ts
@@ -117,7 +117,8 @@ export default class SeedManager {
   ) {
     const argsMatch = Object.entries(source).every(
       ([argumentName, argumentValue]) => {
-        if (typeof argumentValue === 'object') {
+        // null is an object, exclude it from this check
+        if (typeof argumentValue === 'object' && argumentValue != null) {
           return this.matchArguments(argumentValue, target[argumentName]);
         }
         return isEqual(target[argumentName], argumentValue);
@@ -130,7 +131,8 @@ export default class SeedManager {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private argumentCount(args: Record<string, any>) {
     return Object.entries(args).reduce((acc, [, value]) => {
-      if (typeof value === 'object') {
+      // null is an object,  exclude it from this check
+      if (typeof value === 'object' && value != null) {
         return acc + this.argumentCount(value) + 1;
       }
 


### PR DESCRIPTION
## Description

When using this package to mock relay pagination spec, ran into the following failures: 

```
[gql:mocks] /Users/sorsini/code/os/gqmock/dist/seed/SeedManager.js:98
[gql:mocks]         return Object.entries(args).reduce((acc, [, value]) => {
[gql:mocks]                       ^
[gql:mocks] 
[gql:mocks] TypeError: Cannot convert undefined or null to object
[gql:mocks]     at Function.entries (<anonymous>)
[gql:mocks]     at SeedManager.argumentCount (/Users/sorsini/code/os/gqmock/dist/seed/SeedManager.js:98:23)
[gql:mocks]     at /Users/sorsini/code/os/gqmock/dist/seed/SeedManager.js:100:35
[gql:mocks]     at Array.reduce (<anonymous>)
[gql:mocks]     at SeedManager.argumentCount (/Users/sorsini/code/os/gqmock/dist/seed/SeedManager.js:98:37)
[gql:mocks]     at /Users/sorsini/code/os/gqmock/dist/seed/SeedManager.js:120:43
[gql:mocks]     at Array.findIndex (<anonymous>)
[gql:mocks]     at SeedManager.findSeed (/Users/sorsini/code/os/gqmock/dist/seed/SeedManager.js:115:69)
[gql:mocks]     at SeedManager.mergeOperationResponse (/Users/sorsini/code/os/gqmock/dist/seed/SeedManager.js:137:42)
[gql:mocks]     at /Users/sorsini/code/os/gqmock/dist/routes/graphql.js:74:69
```

```
[gql:mocks] /Users/sorsini/code/os/gqmock/dist/seed/SeedManager.js:87
[gql:mocks]         const argsMatch = Object.entries(source).every(([argumentName, argumentValue]) => {
[gql:mocks]                                  ^
[gql:mocks] 
[gql:mocks] TypeError: Cannot convert undefined or null to object
[gql:mocks]     at Function.entries (<anonymous>)
[gql:mocks]     at SeedManager.matchArguments (/Users/sorsini/code/os/gqmock/dist/seed/SeedManager.js:87:34)
[gql:mocks]     at /Users/sorsini/code/os/gqmock/dist/seed/SeedManager.js:90:29
[gql:mocks]     at Array.every (<anonymous>)
[gql:mocks]     at SeedManager.matchArguments (/Users/sorsini/code/os/gqmock/dist/seed/SeedManager.js:87:50)
[gql:mocks]     at /Users/sorsini/code/os/gqmock/dist/seed/SeedManager.js:116:36
[gql:mocks]     at Array.findIndex (<anonymous>)
[gql:mocks]     at SeedManager.findSeed (/Users/sorsini/code/os/gqmock/dist/seed/SeedManager.js:115:69)
[gql:mocks]     at SeedManager.mergeOperationResponse (/Users/sorsini/code/os/gqmock/dist/seed/SeedManager.js:137:42)
[gql:mocks]     at /Users/sorsini/code/os/gqmock/dist/routes/graphql.js:74:69
``` 
due to some of the arguments being intentionally `null` (for example, the `cursor` on a [refetch](https://relay.dev/docs/guided-tour/list-data/refetching-connections/). 

Tested fix on several different mocks including the above `null`s!


## Type of Change

- [X] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](https://github.com/wayfair-incubator/gqmock/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
