### PR TITLE
feat: support unions when building private queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [v1.2.1] - 2023-12-15
+
+### Fixed
+
+- feat: support unions when building private queries
+
 ## [v1.2.0] - 2023-11-01
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wayfair/gqmock",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "GQMock - GraphQL Mocking Service",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/ApolloServerManager.ts
+++ b/src/ApolloServerManager.ts
@@ -319,4 +319,27 @@ export default class ApolloServerManager {
 
     return [];
   }
+
+  getUnionImplementations(schema: GraphQLSchema, typeName: string): string[] {
+    const schemaAst = parse(printSchema(schema));
+    const unionTypeDefinitions = schemaAst.definitions.filter((definition) => {
+      return definition.kind === Kind.UNION_TYPE_DEFINITION;
+    });
+
+    if (unionTypeDefinitions && unionTypeDefinitions.length > 0) {
+      return (
+        unionTypeDefinitions
+          .filter((unionTypeDefinition) =>
+            // @ts-expect-error We know this is a union type definition
+            unionTypeDefinition?.types?.find(
+              (typeDefinition) => typeDefinition.name.value === typeName
+            )
+          )
+          // @ts-expect-error We know this is a union type definition
+          .map((unionTypeDefinition) => unionTypeDefinition.name.value) || []
+      );
+    }
+
+    return [];
+  }
 }

--- a/src/__fixtures__/schema.graphql
+++ b/src/__fixtures__/schema.graphql
@@ -55,6 +55,8 @@ type SubItemThree implements SubItem {
   field3: String
 }
 
+union RandomThing = ItemOne | ItemTwo | ItemThree
+
 interface Item {
   id: String
   type: String
@@ -101,6 +103,7 @@ type Query {
   productByName(name: String!): Product
   productBySku(sku: String!): Product
   item: Item
+  random: RandomThing
   items(type: String): [Item]
 }
 

--- a/src/utilities/buildPrivateTypeQuery.ts
+++ b/src/utilities/buildPrivateTypeQuery.ts
@@ -52,6 +52,10 @@ export default function ({
       apolloServerManager.schema as GraphQLSchema,
       typeName
     );
+  const unionImplementations = apolloServerManager.getUnionImplementations(
+    apolloServerManager.schema as GraphQLSchema,
+    typeName
+  );
   const queryAst = parse(query);
   let node: ASTNode = queryAst.definitions.find((definition) => {
     return (
@@ -158,9 +162,12 @@ export default function ({
             );
           } else if (
             selection.typeCondition &&
-            interfaceImplementations.includes(
+            (unionImplementations.includes(
               selection.typeCondition.name.value
-            )
+            ) ||
+              interfaceImplementations.includes(
+                selection.typeCondition.name.value
+              ))
           ) {
             subQueryNodesToVisit.push(selection);
           }


### PR DESCRIPTION
## Description

Address a bug where inline fragments on Union types are not properly respected when re-resolving a partial query for a specific field in the query request.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](https://github.com/wayfair-incubator/gqmock/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
