### PR TITLE
fix: support multiple nodes in private queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,17 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [v1.2.2] - 2023-12-21
+
+### Fixed
+
+- fix: support multiple nodes in private queries
+
 ## [v1.2.1] - 2023-12-15
 
 ### Fixed
 
-- feat: support unions when building private queries
+- fix: support unions when building private queries
 
 ## [v1.2.0] - 2023-11-01
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wayfair/gqmock",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "GQMock - GraphQL Mocking Service",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/__fixtures__/schema.graphql
+++ b/src/__fixtures__/schema.graphql
@@ -105,6 +105,25 @@ type Query {
   item: Item
   random: RandomThing
   items(type: String): [Item]
+  itemConnection(type: String): ItemConnection
+}
+
+type ItemConnection {
+  totalCount: Int
+  edges: [ItemEdge]
+  pageInfo: PageInfo
+}
+
+type PageInfo {
+  hasNextPage: Boolean
+  hasPreviousPage: Boolean
+  startCursor: String
+  endCursor: String
+}
+
+type ItemEdge {
+  node: Item
+  cursor: String
 }
 
 enum SomeEnum {


### PR DESCRIPTION
## Description

When multiple deeply nested objects are accessed inside a query, the mock server incorrectly resolves values using only one of the objects. This change ensures that all matching paths are merged together prior to mocking out data to ensure the full request is properly mocked regardless of how the query is composed.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wayfair-incubator/gqmock/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
