### PR TITLE
fix: support variables nested in query when making private queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [v1.3.1] - 2024-02-08
+
+### Fixed
+
+- fix: support variables nested in query when making private queries
+
 ## [v1.3.0] - 2024-02-02
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wayfair/gqmock",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "GQMock - GraphQL Mocking Service",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/ApolloServerManager.ts
+++ b/src/ApolloServerManager.ts
@@ -197,11 +197,13 @@ export default class ApolloServerManager {
 
   async getNewMock({
     query,
+    variables,
     typeName,
     operationName,
     rollingKey,
   }: {
     query: string;
+    variables: Record<string, unknown>;
     typeName: string;
     operationName: string;
     rollingKey: string;
@@ -213,9 +215,10 @@ export default class ApolloServerManager {
       rollingKey,
       apolloServerManager: this,
     });
+
     const queryResult = await this.executeOperation({
       query: newQuery,
-      variables: {},
+      variables,
       operationName: this.getFieldName('privateQuery'),
     });
 

--- a/src/seed/SeedManager.ts
+++ b/src/seed/SeedManager.ts
@@ -238,6 +238,7 @@ export default class SeedManager {
             {
               apolloServerManager,
               query,
+              variables,
               operationName,
             }
           );

--- a/src/utilities/__tests__/buildPrivateTypeQuery.ts
+++ b/src/utilities/__tests__/buildPrivateTypeQuery.ts
@@ -174,8 +174,8 @@ describe('buildPrivateTypeQuery', function () {
 
   it('should build a query for the correct nested inline fragment', () => {
     const rollingKey = 'data.item.subItem1';
-    const query = `query itemQuery {
-        item {
+    const query = `query itemQuery($first: Int!, $second: String!) {
+        item(first: $first) {
             __typename
             id
             ... on ItemOne {
@@ -183,8 +183,11 @@ describe('buildPrivateTypeQuery', function () {
                 subItem1 {
                     __typename
                     id
+                    fieldWithVariable(first: $first)
                     ... on SubItemOne {
                         field1
+                        anotherWithSameVariable(first: $first)
+                        anotherWithDifferentVariable(second: $second)
                     }
                     ... on SubItemTwo {
                         field2
@@ -209,11 +212,14 @@ describe('buildPrivateTypeQuery', function () {
         }
     }`;
 
-    const expectedQuery = `query gqmock_privateQuery {
+    const expectedQuery = `query gqmock_privateQuery($first: Int!, $second: String!) {
   gqmock_SubItemOne {
     __typename
     id
+    fieldWithVariable(first: $first)
     field1
+    anotherWithSameVariable(first: $first)
+    anotherWithDifferentVariable(second: $second)
   }
   __typename
 }`;

--- a/src/utilities/deepMerge.ts
+++ b/src/utilities/deepMerge.ts
@@ -48,6 +48,7 @@ function buildShorthandOverridesMap(object, metaPropertyPrefix) {
  * @param {string} graphqlContext.operationName - GraphQL operation name
  * @param {ApolloServerManager} graphqlContext.apolloServerManager - ApolloServerManager instance
  * @param {object} options - Merge options
+ * @param graphqlContext.variables
  * @returns {object} A merged object and a list of warnings
  */
 async function deepMerge(
@@ -55,6 +56,7 @@ async function deepMerge(
   seed: Record<string, unknown>,
   graphqlContext: {
     query: string;
+    variables: Record<string, unknown>;
     operationName: string;
     apolloServerManager: ApolloServerManager;
   },
@@ -63,7 +65,7 @@ async function deepMerge(
   data: Record<string, unknown>;
   warnings: string[];
 }> {
-  const {query, operationName, apolloServerManager} = graphqlContext;
+  const {query, operationName, apolloServerManager, variables} = graphqlContext;
   const warnings = new Set<string>();
   /**
    * Returns the result of merging target into source
@@ -87,6 +89,7 @@ async function deepMerge(
     ) {
       source = await apolloServerManager.getNewMock({
         query,
+        variables,
         typeName: target.__typename,
         operationName,
         rollingKey,
@@ -107,6 +110,7 @@ async function deepMerge(
             // this should happen regardless of overrides
             const newSourceItemData = await apolloServerManager.getNewMock({
               query,
+              variables,
               typeName: sourceItem.__typename,
               operationName,
               rollingKey: newRollingKey,
@@ -145,6 +149,7 @@ async function deepMerge(
                 // this should happen regardless of overrides
                 const newSourceItemData = await apolloServerManager.getNewMock({
                   query,
+                  variables,
                   typeName: sourceItem.__typename,
                   operationName,
                   rollingKey: newRollingKey,


### PR DESCRIPTION
## Description

Add support for nested variables when executing "private" queries in order to respect seed requests.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](https://github.com/wayfair-incubator/gqmock/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
